### PR TITLE
#3 Remove duplicate CORS headers from ApiResult

### DIFF
--- a/src/Value/Result/ApiResult.php
+++ b/src/Value/Result/ApiResult.php
@@ -30,10 +30,6 @@ class ApiResult
 
         return $response
             ->withStatus($this->statusCode)
-            ->withHeader('Content-Type', 'application/json')
-            ->withHeader('Access-Control-Allow-Origin', '*')
-            ->withHeader('Access-Control-Allow-Methods', 'GET, POST, PUT, DELETE, OPTIONS')
-            ->withHeader('Access-Control-Allow-Headers', '*')
-            ->withHeader('Access-Control-Max-Age', '86400');
+            ->withHeader('Content-Type', 'application/json');
     }
 }


### PR DESCRIPTION
## Summary
- Stripped `Access-Control-Allow-*` headers from `ApiResult::getResponse()`
- `CORSMiddleware` is already registered globally via `$app->add()` and handles all CORS — no duplication needed

## Test plan
- [ ] CORS headers still present on responses (set by middleware)
- [ ] No duplicate headers

🤖 Generated with [Claude Code](https://claude.com/claude-code)