### PR TITLE
#5 Standardize repository method naming conventions

### DIFF
--- a/src/Api/ApiKey/Service/ApiKeyService.php
+++ b/src/Api/ApiKey/Service/ApiKeyService.php
@@ -61,7 +61,7 @@ class ApiKeyService
     public function getAllKeys(ServerRequestInterface $request): ApiResult
     {
         $filter = ApiKeyExtraFilter::parseFromQuery($request->getQueryParams());
-        $apiKeys = $this->repository->loadAll($filter);
+        $apiKeys = $this->repository->getAll($filter);
 
         if ($apiKeys->count() === 0) {
             return ApiResult::from(

--- a/src/Api/Click/Service/ClickService.php
+++ b/src/Api/Click/Service/ClickService.php
@@ -78,7 +78,7 @@ class ClickService
     public function getAllClicks(ServerRequestInterface $request): ApiResult
     {
         $filter = ClickExtraFilter::parseFromQuery($request->getQueryParams());
-        $clicks = $this->repository->listAll($filter);
+        $clicks = $this->repository->getAll($filter);
         /** @var Clicks $clicksData */
         $clicksData = $clicks->getData();
 

--- a/src/Api/LinkCollection/Service/LinkCollectionService.php
+++ b/src/Api/LinkCollection/Service/LinkCollectionService.php
@@ -38,7 +38,7 @@ class LinkCollectionService
         }
 
         $linkId = LinkId::fromString($attributes['linkId']);
-        $link = $this->repository->getById($linkId);
+        $link = $this->repository->findById($linkId);
 
         if ($link === null) {
             return ApiResult::from(
@@ -112,7 +112,7 @@ class LinkCollectionService
         }
 
         $linkId = LinkId::fromString($params['linkId']);
-        $link = $this->repository->getById($linkId);
+        $link = $this->repository->findById($linkId);
 
         if (!$link) {
             return ApiResult::from(
@@ -133,7 +133,7 @@ class LinkCollectionService
     {
         $linkId = (int)$request->getAttribute('linkId');
 
-        $linkItem = $this->repository->getById(LinkId::fromInt($linkId));
+        $linkItem = $this->repository->findById(LinkId::fromInt($linkId));
 
         if (!$linkItem) {
             return ApiResult::from(

--- a/src/Api/PreviewToken/Service/PreviewTokenService.php
+++ b/src/Api/PreviewToken/Service/PreviewTokenService.php
@@ -45,7 +45,7 @@ class PreviewTokenService
             $createdBy,
         );
 
-        $this->repository->createToken($token);
+        $this->repository->create($token);
 
         return ApiResult::from(
             JsonResult::from('Token created', ['token' => $token->getToken()]),
@@ -72,7 +72,7 @@ class PreviewTokenService
 
     public function editToken(ServerRequestInterface $request, ResponseInterface $response): ResponseInterface
     {
-        $token = $this->repository->getToken($request->getAttribute('tokenId'));
+        $token = $this->repository->findById($request->getAttribute('tokenId'));
 
         if (!$token) {
             return ApiResult::from(
@@ -94,7 +94,7 @@ class PreviewTokenService
 
     public function deleteToken(ServerRequestInterface $request, ResponseInterface $response): ResponseInterface
     {
-        $token = $this->repository->getToken($request->getAttribute('tokenId'));
+        $token = $this->repository->findById($request->getAttribute('tokenId'));
 
         if (!$token) {
             return ApiResult::from(
@@ -102,7 +102,7 @@ class PreviewTokenService
             )->getResponse($response);
         }
 
-        $this->repository->deleteToken($token->getToken());
+        $this->repository->delete($token->getToken());
 
         return ApiResult::from(
             JsonResult::from('Token deleted'),

--- a/src/Api/User/Service/UserService.php
+++ b/src/Api/User/Service/UserService.php
@@ -193,7 +193,7 @@ class UserService
             )->getResponse($response);
         }
 
-        $this->repository->deleteUser(UserId::fromString($userId));
+        $this->repository->delete(UserId::fromString($userId));
 
         return ApiResult::from(
             JsonResult::from('User deleted'),

--- a/src/Api/WebTracking/Identify/Service/TrackingUserService.php
+++ b/src/Api/WebTracking/Identify/Service/TrackingUserService.php
@@ -28,7 +28,7 @@ class TrackingUserService
     {
         $body = $request->getParsedBody();
 
-        $siteConfiguration = $this->siteRepository->getSite($body['siteId']);
+        $siteConfiguration = $this->siteRepository->findById($body['siteId']);
         if (!$siteConfiguration) {
             return ApiResult::from(
                 JsonResult::from('Site not found'),
@@ -49,7 +49,7 @@ class TrackingUserService
             $existingAlias = $this->trackingUserAliasRepository->getUserAlias((int)$siteId, $anonymousId);
 
             if (!$existingAlias) {
-                $this->trackingUserAliasRepository->insertUserAlias($trackingUser);
+                $this->trackingUserAliasRepository->create($trackingUser);
 
                 return ApiResult::from(
                     JsonResult::from(

--- a/src/Api/WebTracking/SiteConfig/Service/SiteConfigService.php
+++ b/src/Api/WebTracking/SiteConfig/Service/SiteConfigService.php
@@ -19,7 +19,7 @@ class SiteConfigService
 
     public function getSite(int $siteId): ApiResult
     {
-        $site = $this->siteRepository->getSite($siteId);
+        $site = $this->siteRepository->findById($siteId);
 
         if (!$site) {
             return ApiResult::from(
@@ -39,7 +39,7 @@ class SiteConfigService
 
     public function getSiteConfig(int $siteId): ApiResult
     {
-        $site = $this->siteRepository->getSite($siteId);
+        $site = $this->siteRepository->findById($siteId);
 
         if (!$site) {
             return ApiResult::from(
@@ -60,7 +60,7 @@ class SiteConfigService
     public function updateSiteConfig(int $siteId, array $parsedBody): ApiResult
     {
         // TODO: Check if domain changed and already exists
-        $site = $this->siteRepository->getSite($siteId);
+        $site = $this->siteRepository->findById($siteId);
 
         if (!$site) {
             return ApiResult::from(

--- a/src/Repository/ApiKeyRepository.php
+++ b/src/Repository/ApiKeyRepository.php
@@ -58,7 +58,7 @@ class ApiKeyRepository
         $this->addPermissions($keyId, $keyObject->getPermissions());
     }
 
-    public function loadAll(ApiKeyExtraFilter $filter): ApiKeyObjects
+    public function getAll(ApiKeyExtraFilter $filter): ApiKeyObjects
     {
         $select = $this->queryFactory
             ->select(

--- a/src/Repository/ClickRepository.php
+++ b/src/Repository/ClickRepository.php
@@ -134,7 +134,7 @@ class ClickRepository
         }
     }
 
-    public function listAll(ClickExtraFilter $filter): PaginatedData
+    public function getAll(ClickExtraFilter $filter): PaginatedData
     {
         $select = $this->queryFactory->select(
             'lc.displayname',

--- a/src/Repository/LinkCollectionRepository.php
+++ b/src/Repository/LinkCollectionRepository.php
@@ -80,7 +80,7 @@ class LinkCollectionRepository
         return LinkItem::fromDatabase($row);
     }
 
-    public function getById(LinkId $linkId): ?LinkItem
+    public function findById(LinkId $linkId): ?LinkItem
     {
         if ($linkItem = $this->caching->getItem($linkId)) {
             return $linkItem;

--- a/src/Repository/PreviewTokenRepository.php
+++ b/src/Repository/PreviewTokenRepository.php
@@ -18,7 +18,7 @@ class PreviewTokenRepository
     ) {
     }
 
-    public function createToken(PreviewToken $token): void
+    public function create(PreviewToken $token): void
     {
         $sql = <<<SQL
             INSERT INTO preview_access_tokens (token, max_uses, is_active, created_by, created_at)
@@ -122,7 +122,7 @@ class PreviewTokenRepository
         }
     }
 
-    public function getToken(string $tokenId): ?PreviewToken
+    public function findById(string $tokenId): ?PreviewToken
     {
         $sql = <<<SQL
             SELECT 
@@ -177,7 +177,7 @@ class PreviewTokenRepository
         }
     }
 
-    public function deleteToken(string $tokenId): void
+    public function delete(string $tokenId): void
     {
         $sql = <<<SQL
             DELETE FROM preview_access_tokens WHERE token = :token

--- a/src/Repository/SiteRepository.php
+++ b/src/Repository/SiteRepository.php
@@ -16,7 +16,7 @@ class SiteRepository
     ) {
     }
 
-    public function getSite(int $siteId): ?Site
+    public function findById(int $siteId): ?Site
     {
         $sql = <<<SQL
             SELECT * FROM sites WHERE site_id = :siteId

--- a/src/Repository/TrackingUserAliasRepository.php
+++ b/src/Repository/TrackingUserAliasRepository.php
@@ -45,7 +45,7 @@ class TrackingUserAliasRepository
         return $result;
     }
 
-    public function insertUserAlias(TrackingUser $user): void
+    public function create(TrackingUser $user): void
     {
         $sql = <<<SQL
             INSERT INTO 

--- a/src/Repository/UserRepository.php
+++ b/src/Repository/UserRepository.php
@@ -192,7 +192,7 @@ class UserRepository
         return Users::from(...$users);
     }
 
-    public function deleteUser(UserId $userId): void
+    public function delete(UserId $userId): void
     {
         $sql = <<<SQL
             DELETE FROM users WHERE user_id = :user_id

--- a/src/Service/PreviewTokenValidationService.php
+++ b/src/Service/PreviewTokenValidationService.php
@@ -17,7 +17,7 @@ class PreviewTokenValidationService
 
     public function validatePreviewToken(string $token): void
     {
-        $token = $this->tokenRepository->getToken($token);
+        $token = $this->tokenRepository->findById($token);
 
         if (!$token) {
             throw new InvalidPreviewTokenException('Invalid preview token');


### PR DESCRIPTION
## Summary
- Inserts → `create()`, primary-key selects → `findById()`, deletes → `delete()`
- `ClickRepository::listAll()` → `getAll()`, `ApiKeyRepository::loadAll()` → `getAll()`
- `LinkCollectionRepository::getById()` → `findById()`
- `SiteRepository::getSite()` → `findById()`
- `TrackingUserAliasRepository::insertUserAlias()` → `create()`
- `PreviewTokenRepository`: `createToken` → `create`, `getToken` → `findById`, `deleteToken` → `delete`
- All call sites in services updated accordingly
- `recordClick` kept as-is (intentional naming)

## Test plan
- [ ] `php -l` on all changed files: no syntax errors
- [ ] No remaining references to old method names

🤖 Generated with [Claude Code](https://claude.com/claude-code)