### PR TITLE
#6 Extract PDO transaction boilerplate into TransactionTrait

### DIFF
--- a/src/Repository/Traits/TransactionTrait.php
+++ b/src/Repository/Traits/TransactionTrait.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LukaLtaApi\Repository\Traits;
+
+use LukaLtaApi\Exception\ApiDatabaseException;
+use PDO;
+use PDOException;
+
+trait TransactionTrait
+{
+    public function executeInTransaction(callable $fn): mixed
+    {
+        /** @var PDO $pdo */
+        $pdo = $this->pdo;
+        $pdo->beginTransaction();
+        try {
+            $result = $fn();
+            $pdo->commit();
+            return $result;
+        } catch (PDOException $e) {
+            $pdo->rollBack();
+            throw new ApiDatabaseException($e->getMessage(), (int) $e->getCode(), $e);
+        }
+    }
+}

--- a/src/Repository/UserRepository.php
+++ b/src/Repository/UserRepository.php
@@ -2,10 +2,9 @@
 
 namespace LukaLtaApi\Repository;
 
-use Fig\Http\Message\StatusCodeInterface;
 use Latitude\QueryBuilder\QueryFactory;
 use LukaLtaApi\Api\User\Value\UserExtraFilter;
-use LukaLtaApi\Exception\ApiDatabaseException;
+use LukaLtaApi\Repository\Traits\TransactionTrait;
 use LukaLtaApi\Value\User\User;
 use LukaLtaApi\Value\User\UserEmail;
 use LukaLtaApi\Value\User\UserId;
@@ -15,6 +14,7 @@ use PDOException;
 
 class UserRepository
 {
+    use TransactionTrait;
     public function __construct(
         private readonly PDO $pdo,
         private readonly QueryFactory $queryFactory,
@@ -28,8 +28,7 @@ class UserRepository
             VALUES (:email, :username, :password, :avatar_url)
         SQL;
 
-        $this->pdo->beginTransaction();
-        try {
+        $this->executeInTransaction(function () use ($sql, $user): void {
             $statement = $this->pdo->prepare($sql);
             $statement->execute([
                 'email' => $user->getEmail()->asString(),
@@ -37,15 +36,7 @@ class UserRepository
                 'password' => $user->getPassword()->asString(),
                 'avatar_url' => $user->getAvatarUrl(),
             ]);
-            $this->pdo->commit();
-        } catch (PDOException $e) {
-            $this->pdo->rollBack();
-            throw new ApiDatabaseException(
-                'Failed to create user',
-                StatusCodeInterface::STATUS_INTERNAL_SERVER_ERROR,
-                $e
-            );
-        }
+        });
     }
 
     public function update(User $user): void
@@ -62,8 +53,7 @@ class UserRepository
             WHERE user_id = :user_id
         SQL;
 
-        $this->pdo->beginTransaction();
-        try {
+        $this->executeInTransaction(function () use ($sql, $user): void {
             $statement = $this->pdo->prepare($sql);
             $statement->execute([
                 'username' => $user->getUsername(),
@@ -74,15 +64,7 @@ class UserRepository
                 'is_active' => (int)$user->isActive(),
                 'last_active' => $user->getLastActive()?->format('Y-m-d H:i:s'),
             ]);
-            $this->pdo->commit();
-        } catch (PDOException $e) {
-            $this->pdo->rollBack();
-            throw new ApiDatabaseException(
-                'Failed to update user',
-                StatusCodeInterface::STATUS_INTERNAL_SERVER_ERROR,
-                $e
-            );
-        }
+        });
     }
 
     public function findByEmail(UserEmail $email, ?UserId $excludeUserId = null): ?User
@@ -198,17 +180,9 @@ class UserRepository
             DELETE FROM users WHERE user_id = :user_id
         SQL;
 
-        $this->pdo->beginTransaction();
-        try {
+        $this->executeInTransaction(function () use ($sql, $userId): void {
             $stmt = $this->pdo->prepare($sql);
             $stmt->execute(['user_id' => $userId->asInt()]);
-            $this->pdo->commit();
-        } catch (PDOException $exception) {
-            $this->pdo->rollBack();
-            throw new ApiDatabaseException(
-                'Failed to delete user',
-                previous: $exception
-            );
-        }
+        });
     }
 }


### PR DESCRIPTION
## Summary
- New `src/Repository/Traits/TransactionTrait.php` with `executeInTransaction(callable): mixed`
- `UserRepository` (only repo using explicit transactions) now uses the trait
- Replaces 3 repetitive `beginTransaction/commit/rollBack/throw` blocks

## Test plan
- [ ] `php -l` on all changed files: no syntax errors
- [ ] User create/update/delete still wrap correctly in transactions

🤖 Generated with [Claude Code](https://claude.com/claude-code)