### PR TITLE
#7 Add interfaces for all shared services

### DIFF
--- a/src/Api/Auth/Service/AuthService.php
+++ b/src/Api/Auth/Service/AuthService.php
@@ -5,7 +5,7 @@ namespace LukaLtaApi\Api\Auth\Service;
 use DateTimeImmutable;
 use Fig\Http\Message\StatusCodeInterface;
 use LukaLtaApi\Repository\UserRepository;
-use LukaLtaApi\Service\TokenService;
+use LukaLtaApi\Service\Contracts\TokenServiceInterface;
 use LukaLtaApi\Value\Result\ApiResult;
 use LukaLtaApi\Value\Result\JsonResult;
 use LukaLtaApi\Value\User\UserEmail;
@@ -15,7 +15,7 @@ class AuthService
 {
     public function __construct(
         private readonly UserRepository $repository,
-        private readonly TokenService $tokenService,
+        private readonly TokenServiceInterface $tokenService,
     ) {
     }
 

--- a/src/Api/Register/Service/RegisterService.php
+++ b/src/Api/Register/Service/RegisterService.php
@@ -9,8 +9,8 @@ use LukaLtaApi\Exception\InvalidPreviewTokenException;
 use LukaLtaApi\Exception\UserAlreadyExistsException;
 use LukaLtaApi\Repository\PreviewTokenRepository;
 use LukaLtaApi\Repository\UserRepository;
-use LukaLtaApi\Service\PreviewTokenValidationService;
-use LukaLtaApi\Service\UserValidationService;
+use LukaLtaApi\Service\Contracts\PreviewTokenValidationServiceInterface;
+use LukaLtaApi\Service\Contracts\UserValidationServiceInterface;
 use LukaLtaApi\Value\Result\ApiResult;
 use LukaLtaApi\Value\Result\JsonResult;
 use LukaLtaApi\Value\User\User;
@@ -21,8 +21,8 @@ class RegisterService
 {
     public function __construct(
         private readonly UserRepository $userRepository,
-        private readonly UserValidationService $userValidationService,
-        private readonly PreviewTokenValidationService $previewTokenValidationService,
+        private readonly UserValidationServiceInterface $userValidationService,
+        private readonly PreviewTokenValidationServiceInterface $previewTokenValidationService,
     ) {
     }
 

--- a/src/Api/SelfUser/Service/SelfUserService.php
+++ b/src/Api/SelfUser/Service/SelfUserService.php
@@ -8,8 +8,8 @@ use Fig\Http\Message\StatusCodeInterface;
 use LukaLtaApi\Exception\ApiAvatarUploadException;
 use LukaLtaApi\Exception\UserAlreadyExistsException;
 use LukaLtaApi\Repository\UserRepository;
-use LukaLtaApi\Service\AvatarService;
-use LukaLtaApi\Service\UserValidationService;
+use LukaLtaApi\Service\Contracts\AvatarServiceInterface;
+use LukaLtaApi\Service\Contracts\UserValidationServiceInterface;
 use LukaLtaApi\Value\Result\ApiResult;
 use LukaLtaApi\Value\Result\JsonResult;
 use LukaLtaApi\Value\User\UserEmail;
@@ -21,8 +21,8 @@ class SelfUserService
 {
     public function __construct(
         private readonly UserRepository        $repository,
-        private readonly UserValidationService $validationService,
-        private readonly AvatarService         $avatarService,
+        private readonly UserValidationServiceInterface $validationService,
+        private readonly AvatarServiceInterface         $avatarService,
     ) {
     }
 

--- a/src/Api/User/Service/UserService.php
+++ b/src/Api/User/Service/UserService.php
@@ -10,8 +10,8 @@ use LukaLtaApi\Exception\ApiAvatarUploadException;
 use LukaLtaApi\Exception\UserAlreadyExistsException;
 use LukaLtaApi\Repository\S3Repository;
 use LukaLtaApi\Repository\UserRepository;
-use LukaLtaApi\Service\AvatarService;
-use LukaLtaApi\Service\UserValidationService;
+use LukaLtaApi\Service\Contracts\AvatarServiceInterface;
+use LukaLtaApi\Service\Contracts\UserValidationServiceInterface;
 use LukaLtaApi\Value\Result\ApiResult;
 use LukaLtaApi\Value\Result\JsonResult;
 use LukaLtaApi\Value\User\User;
@@ -24,8 +24,8 @@ class UserService
 {
     public function __construct(
         private readonly UserRepository $repository,
-        private readonly UserValidationService $validationService,
-        private readonly AvatarService $avatarService,
+        private readonly UserValidationServiceInterface $validationService,
+        private readonly AvatarServiceInterface $avatarService,
         private readonly S3Repository $s3Repository,
     ) {
     }

--- a/src/Api/WebTracking/Identify/Service/TrackingUserService.php
+++ b/src/Api/WebTracking/Identify/Service/TrackingUserService.php
@@ -7,7 +7,7 @@ namespace LukaLtaApi\Api\WebTracking\Identify\Service;
 use Fig\Http\Message\StatusCodeInterface;
 use LukaLtaApi\Repository\SiteRepository;
 use LukaLtaApi\Repository\TrackingUserAliasRepository;
-use LukaLtaApi\Service\CryptService;
+use LukaLtaApi\Service\Contracts\CryptServiceInterface;
 use LukaLtaApi\Value\Result\ApiResult;
 use LukaLtaApi\Value\Result\JsonResult;
 use LukaLtaApi\Value\Tracking\User\TrackingUser;
@@ -18,7 +18,7 @@ class TrackingUserService
 {
     public function __construct(
         private readonly SiteRepository $siteRepository,
-        private readonly CryptService $cryptService,
+        private readonly CryptServiceInterface $cryptService,
         private readonly TrackingUserAliasRepository $trackingUserAliasRepository,
         private readonly LoggerInterface $logger,
     ) {

--- a/src/Api/WebTracking/TrackEvent/Service/EventHandleService.php
+++ b/src/Api/WebTracking/TrackEvent/Service/EventHandleService.php
@@ -8,8 +8,8 @@ use DateTimeImmutable;
 use LukaLtaApi\Api\WebTracking\TrackEvent\Repository\TrackEventRepository;
 use LukaLtaApi\Repository\GeoLocationRepository;
 use LukaLtaApi\Repository\SessionRepository;
-use LukaLtaApi\Service\ChannelDetectorService;
-use LukaLtaApi\Service\CryptService;
+use LukaLtaApi\Service\Contracts\ChannelDetectorServiceInterface;
+use LukaLtaApi\Service\Contracts\CryptServiceInterface;
 use LukaLtaApi\Value\Device;
 use LukaLtaApi\Value\GeoLocation;
 use LukaLtaApi\Value\UserAgent;
@@ -21,9 +21,9 @@ use Throwable;
 class EventHandleService
 {
     public function __construct(
-        private readonly ChannelDetectorService $channelDetector,
-        private readonly TrackEventRepository   $trackEventRepository,
-        private readonly CryptService           $cryptService,
+        private readonly ChannelDetectorServiceInterface $channelDetector,
+        private readonly TrackEventRepository            $trackEventRepository,
+        private readonly CryptServiceInterface           $cryptService,
         private readonly SessionRepository      $sessionRepository,
         private readonly GeoLocationRepository  $geoLocationRepository,
     ) {

--- a/src/ApplicationConfig.php
+++ b/src/ApplicationConfig.php
@@ -12,12 +12,31 @@ use LukaLtaApi\App\Factory\MinIOFactory;
 use LukaLtaApi\App\Factory\PdoFactory;
 use LukaLtaApi\App\Factory\RedisFactory;
 use LukaLtaApi\App\Factory\TelegramBotFactory;
+use LukaLtaApi\Service\AvatarService;
+use LukaLtaApi\Service\ChannelDetectorService;
+use LukaLtaApi\Service\Contracts\AvatarServiceInterface;
+use LukaLtaApi\Service\Contracts\ChannelDetectorServiceInterface;
+use LukaLtaApi\Service\Contracts\CryptServiceInterface;
+use LukaLtaApi\Service\Contracts\LinkItemCachingServiceInterface;
+use LukaLtaApi\Service\Contracts\PaginationServiceInterface;
+use LukaLtaApi\Service\Contracts\PermissionServiceInterface;
+use LukaLtaApi\Service\Contracts\PreviewTokenValidationServiceInterface;
+use LukaLtaApi\Service\Contracts\TokenServiceInterface;
+use LukaLtaApi\Service\Contracts\UserValidationServiceInterface;
+use LukaLtaApi\Service\CryptService;
+use LukaLtaApi\Service\LinkItemCachingService;
+use LukaLtaApi\Service\PaginationService;
+use LukaLtaApi\Service\PermissionService;
+use LukaLtaApi\Service\PreviewTokenValidationService;
+use LukaLtaApi\Service\TokenService;
+use LukaLtaApi\Service\UserValidationService;
 use LukaLtaApi\Value\Misc\AppEnv;
 use PDO;
 use Psr\Log\LoggerInterface;
 use Redis;
 use TelegramBot\Api\BotApi;
 
+use function DI\autowire;
 use function DI\factory;
 
 class ApplicationConfig extends DefinitionArray
@@ -35,6 +54,15 @@ class ApplicationConfig extends DefinitionArray
             BotApi::class => factory(TelegramBotFactory::class),
             S3Client::class => factory(MinIOFactory::class),
             Client::class => factory(ClickHouseFactory::class),
+            AvatarServiceInterface::class => autowire(AvatarService::class),
+            ChannelDetectorServiceInterface::class => autowire(ChannelDetectorService::class),
+            CryptServiceInterface::class => autowire(CryptService::class),
+            LinkItemCachingServiceInterface::class => autowire(LinkItemCachingService::class),
+            PaginationServiceInterface::class => autowire(PaginationService::class),
+            PermissionServiceInterface::class => autowire(PermissionService::class),
+            PreviewTokenValidationServiceInterface::class => autowire(PreviewTokenValidationService::class),
+            TokenServiceInterface::class => autowire(TokenService::class),
+            UserValidationServiceInterface::class => autowire(UserValidationService::class),
         ];
     }
 }

--- a/src/Repository/ClickRepository.php
+++ b/src/Repository/ClickRepository.php
@@ -8,7 +8,7 @@ use Latitude\QueryBuilder\QueryFactory;
 use LukaLtaApi\Api\Click\Value\ClickExtraFilter;
 use LukaLtaApi\Api\Click\Value\ClicksFilter;
 use LukaLtaApi\Exception\ApiDatabaseException;
-use LukaLtaApi\Service\PaginationService;
+use LukaLtaApi\Service\Contracts\PaginationServiceInterface;
 use LukaLtaApi\Value\PaginatedData;
 use LukaLtaApi\Value\Tracking\Click;
 use LukaLtaApi\Value\Tracking\Clicks;
@@ -24,7 +24,7 @@ class ClickRepository
     public function __construct(
         private readonly PDO $pdo,
         private readonly QueryFactory $queryFactory,
-        private readonly PaginationService $paginationService,
+        private readonly PaginationServiceInterface $paginationService,
     ) {
     }
 

--- a/src/Repository/LinkCollectionRepository.php
+++ b/src/Repository/LinkCollectionRepository.php
@@ -5,7 +5,7 @@ namespace LukaLtaApi\Repository;
 use Latitude\QueryBuilder\QueryFactory;
 use LukaLtaApi\Api\LinkCollection\Value\LinkTreeExtraFilter;
 use LukaLtaApi\Exception\ApiDatabaseException;
-use LukaLtaApi\Service\LinkItemCachingService;
+use LukaLtaApi\Service\Contracts\LinkItemCachingServiceInterface;
 use LukaLtaApi\Value\LinkCollection\LinkId;
 use LukaLtaApi\Value\LinkCollection\LinkItem;
 use LukaLtaApi\Value\LinkCollection\LinkItems;
@@ -17,7 +17,7 @@ class LinkCollectionRepository
 {
     public function __construct(
         private readonly PDO $pdo,
-        private readonly LinkItemCachingService $caching,
+        private readonly LinkItemCachingServiceInterface $caching,
         private readonly QueryFactory $queryFactory,
     ) {
     }

--- a/src/Service/AvatarService.php
+++ b/src/Service/AvatarService.php
@@ -7,10 +7,11 @@ namespace LukaLtaApi\Service;
 use Fig\Http\Message\StatusCodeInterface;
 use LukaLtaApi\Exception\ApiAvatarUploadException;
 use LukaLtaApi\Repository\S3Repository;
+use LukaLtaApi\Service\Contracts\AvatarServiceInterface;
 use LukaLtaApi\Value\User\UserId;
 use Slim\Psr7\UploadedFile;
 
-class AvatarService
+class AvatarService implements AvatarServiceInterface
 {
     public function __construct(
         private readonly S3Repository $s3Repository,

--- a/src/Service/ChannelDetectorService.php
+++ b/src/Service/ChannelDetectorService.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace LukaLtaApi\Service;
 
-class ChannelDetectorService
+use LukaLtaApi\Service\Contracts\ChannelDetectorServiceInterface;
+
+class ChannelDetectorService implements ChannelDetectorServiceInterface
 {
     public function detectChannel(
         ?string $referrer,

--- a/src/Service/Contracts/AvatarServiceInterface.php
+++ b/src/Service/Contracts/AvatarServiceInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LukaLtaApi\Service\Contracts;
+
+use LukaLtaApi\Value\User\UserId;
+use Slim\Psr7\UploadedFile;
+
+interface AvatarServiceInterface
+{
+    public function uploadAvatar(UploadedFile $uploadedFiles, UserId $userId): string;
+}

--- a/src/Service/Contracts/ChannelDetectorServiceInterface.php
+++ b/src/Service/Contracts/ChannelDetectorServiceInterface.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LukaLtaApi\Service\Contracts;
+
+interface ChannelDetectorServiceInterface
+{
+    public function detectChannel(
+        ?string $referrer,
+        ?string $queryString,
+        ?string $hostname,
+    ): string;
+}

--- a/src/Service/Contracts/CryptServiceInterface.php
+++ b/src/Service/Contracts/CryptServiceInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LukaLtaApi\Service\Contracts;
+
+interface CryptServiceInterface
+{
+    public function generateAnonymousId(string $ipAddress, string $userAgent): string;
+}

--- a/src/Service/Contracts/LinkItemCachingServiceInterface.php
+++ b/src/Service/Contracts/LinkItemCachingServiceInterface.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LukaLtaApi\Service\Contracts;
+
+use LukaLtaApi\Value\LinkCollection\LinkId;
+use LukaLtaApi\Value\LinkCollection\LinkItem;
+
+interface LinkItemCachingServiceInterface
+{
+    public function addItem(LinkItem $linkItem): void;
+
+    public function deleteItem(LinkId $linkId): void;
+
+    public function updateItem(LinkItem $item): bool;
+
+    public function getItem(LinkId $linkId): ?LinkItem;
+
+    public function getAllItems(): ?array;
+
+    public function deleteAllItems(): void;
+}

--- a/src/Service/Contracts/PaginationServiceInterface.php
+++ b/src/Service/Contracts/PaginationServiceInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LukaLtaApi\Service\Contracts;
+
+interface PaginationServiceInterface
+{
+    public function getPaginationData(string $table, int $pageSize, array $where = []): array;
+}

--- a/src/Service/Contracts/PermissionServiceInterface.php
+++ b/src/Service/Contracts/PermissionServiceInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LukaLtaApi\Service\Contracts;
+
+use LukaLtaApi\Value\ApiKey\KeyId;
+
+interface PermissionServiceInterface
+{
+    public function hasAccess(KeyId $apiKeyId, array $requiredPermissions): bool;
+}

--- a/src/Service/Contracts/PreviewTokenValidationServiceInterface.php
+++ b/src/Service/Contracts/PreviewTokenValidationServiceInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LukaLtaApi\Service\Contracts;
+
+interface PreviewTokenValidationServiceInterface
+{
+    public function validatePreviewToken(string $token): void;
+}

--- a/src/Service/Contracts/TokenServiceInterface.php
+++ b/src/Service/Contracts/TokenServiceInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LukaLtaApi\Service\Contracts;
+
+use LukaLtaApi\Value\User\User;
+use ReallySimpleJWT\Jwt;
+
+interface TokenServiceInterface
+{
+    public function generateToken(User $user): Jwt;
+}

--- a/src/Service/Contracts/UserValidationServiceInterface.php
+++ b/src/Service/Contracts/UserValidationServiceInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LukaLtaApi\Service\Contracts;
+
+use LukaLtaApi\Value\User\UserEmail;
+use LukaLtaApi\Value\User\UserId;
+
+interface UserValidationServiceInterface
+{
+    public function ensureUserDoesNotExists(
+        UserEmail $email,
+        string $username,
+        ?UserId $excludeUserId = null,
+    ): void;
+}

--- a/src/Service/CryptService.php
+++ b/src/Service/CryptService.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace LukaLtaApi\Service;
 
-class CryptService
+use LukaLtaApi\Service\Contracts\CryptServiceInterface;
+
+class CryptService implements CryptServiceInterface
 {
     public function generateAnonymousId(string $ipAddress, string $userAgent): string
     {

--- a/src/Service/LinkItemCachingService.php
+++ b/src/Service/LinkItemCachingService.php
@@ -2,12 +2,13 @@
 
 namespace LukaLtaApi\Service;
 
+use LukaLtaApi\Service\Contracts\LinkItemCachingServiceInterface;
 use LukaLtaApi\Value\LinkCollection\LinkId;
 use LukaLtaApi\Value\LinkCollection\LinkItem;
 use Redis;
 use RedisException;
 
-class LinkItemCachingService
+class LinkItemCachingService implements LinkItemCachingServiceInterface
 {
     public const string HASH_KEY = 'link_items';
 

--- a/src/Service/PaginationService.php
+++ b/src/Service/PaginationService.php
@@ -5,8 +5,9 @@ declare(strict_types=1);
 namespace LukaLtaApi\Service;
 
 use LukaLtaApi\Repository\PaginationRepository;
+use LukaLtaApi\Service\Contracts\PaginationServiceInterface;
 
-class PaginationService
+class PaginationService implements PaginationServiceInterface
 {
     public function __construct(
         private readonly PaginationRepository $paginationRepository,

--- a/src/Service/PermissionService.php
+++ b/src/Service/PermissionService.php
@@ -5,9 +5,10 @@ declare(strict_types=1);
 namespace LukaLtaApi\Service;
 
 use LukaLtaApi\Repository\ApiKeyRepository;
+use LukaLtaApi\Service\Contracts\PermissionServiceInterface;
 use LukaLtaApi\Value\ApiKey\KeyId;
 
-class PermissionService
+class PermissionService implements PermissionServiceInterface
 {
     public function __construct(
         private readonly ApiKeyRepository $repository

--- a/src/Service/PreviewTokenValidationService.php
+++ b/src/Service/PreviewTokenValidationService.php
@@ -6,9 +6,10 @@ namespace LukaLtaApi\Service;
 
 use LukaLtaApi\Exception\InvalidPreviewTokenException;
 use LukaLtaApi\Repository\PreviewTokenRepository;
+use LukaLtaApi\Service\Contracts\PreviewTokenValidationServiceInterface;
 use LukaLtaApi\Value\Preview\PreviewToken;
 
-class PreviewTokenValidationService
+class PreviewTokenValidationService implements PreviewTokenValidationServiceInterface
 {
     public function __construct(
         private readonly PreviewTokenRepository $tokenRepository,

--- a/src/Service/TokenService.php
+++ b/src/Service/TokenService.php
@@ -3,11 +3,12 @@
 namespace LukaLtaApi\Service;
 
 use LukaLtaApi\Repository\EnvironmentRepository;
+use LukaLtaApi\Service\Contracts\TokenServiceInterface;
 use LukaLtaApi\Value\User\User;
 use ReallySimpleJWT\Jwt;
 use ReallySimpleJWT\Token;
 
-class TokenService
+class TokenService implements TokenServiceInterface
 {
     public function __construct(
         private readonly EnvironmentRepository $environmentRepository,

--- a/src/Service/UserValidationService.php
+++ b/src/Service/UserValidationService.php
@@ -6,10 +6,11 @@ namespace LukaLtaApi\Service;
 
 use LukaLtaApi\Exception\UserAlreadyExistsException;
 use LukaLtaApi\Repository\UserRepository;
+use LukaLtaApi\Service\Contracts\UserValidationServiceInterface;
 use LukaLtaApi\Value\User\UserEmail;
 use LukaLtaApi\Value\User\UserId;
 
-class UserValidationService
+class UserValidationService implements UserValidationServiceInterface
 {
     public function __construct(
         private readonly UserRepository $userRepository,

--- a/src/Slim/Middleware/ApiKeyPermissionMiddleware.php
+++ b/src/Slim/Middleware/ApiKeyPermissionMiddleware.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace LukaLtaApi\Slim\Middleware;
 
 use Fig\Http\Message\StatusCodeInterface;
-use LukaLtaApi\Service\PermissionService;
+use LukaLtaApi\Service\Contracts\PermissionServiceInterface;
 use LukaLtaApi\Value\ApiKey\KeyId;
 use LukaLtaApi\Value\Result\ApiResult;
 use LukaLtaApi\Value\Result\JsonResult;
@@ -18,7 +18,7 @@ use Slim\Psr7\Factory\ResponseFactory;
 class ApiKeyPermissionMiddleware implements MiddlewareInterface
 {
     public function __construct(
-        private readonly PermissionService $service,
+        private readonly PermissionServiceInterface $service,
         private readonly array $permissions
     ) {
     }


### PR DESCRIPTION
## Summary
- New `src/Service/Contracts/` with 9 interfaces: `AvatarServiceInterface`, `ChannelDetectorServiceInterface`, `CryptServiceInterface`, `LinkItemCachingServiceInterface`, `PaginationServiceInterface`, `PermissionServiceInterface`, `PreviewTokenValidationServiceInterface`, `TokenServiceInterface`, `UserValidationServiceInterface`
- All concrete classes implement their interface
- All consumers (services, middleware, repositories) depend on the interface
- Interface→concrete bindings added to `ApplicationConfig` via `autowire()`

## Test plan
- [ ] `composer dump-autoload` passes
- [ ] `php -l` on all changed files: no syntax errors
- [ ] PHP-DI resolves interface→concrete at runtime

🤖 Generated with [Claude Code](https://claude.com/claude-code)