### PR TITLE
#10 Split ClickService — extract analytics into ClickAnalyticsService

### DIFF
--- a/src/Api/Click/Action/GetClickSummaryAction.php
+++ b/src/Api/Click/Action/GetClickSummaryAction.php
@@ -5,14 +5,14 @@ declare(strict_types=1);
 namespace LukaLtaApi\Api\Click\Action;
 
 use LukaLtaApi\Api\ApiAction;
-use LukaLtaApi\Api\Click\Service\ClickService;
+use LukaLtaApi\Api\Click\Service\ClickAnalyticsService;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
 class GetClickSummaryAction extends ApiAction
 {
     public function __construct(
-        private readonly ClickService $service
+        private readonly ClickAnalyticsService $service
     ) {
     }
 

--- a/src/Api/Click/Action/GetClicksFiltersAction.php
+++ b/src/Api/Click/Action/GetClicksFiltersAction.php
@@ -3,14 +3,14 @@
 namespace LukaLtaApi\Api\Click\Action;
 
 use LukaLtaApi\Api\ApiAction;
-use LukaLtaApi\Api\Click\Service\ClickService;
+use LukaLtaApi\Api\Click\Service\ClickAnalyticsService;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
 class GetClicksFiltersAction extends ApiAction
 {
     public function __construct(
-        private readonly ClickService $clickService,
+        private readonly ClickAnalyticsService $clickService,
     ) {
     }
 

--- a/src/Api/Click/Action/GetClicksStatsAction.php
+++ b/src/Api/Click/Action/GetClicksStatsAction.php
@@ -3,14 +3,14 @@
 namespace LukaLtaApi\Api\Click\Action;
 
 use LukaLtaApi\Api\ApiAction;
-use LukaLtaApi\Api\Click\Service\ClickService;
+use LukaLtaApi\Api\Click\Service\ClickAnalyticsService;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
 class GetClicksStatsAction extends ApiAction
 {
     public function __construct(
-        private readonly ClickService $service
+        private readonly ClickAnalyticsService $service
     ) {
     }
 

--- a/src/Api/Click/Service/ClickAnalyticsService.php
+++ b/src/Api/Click/Service/ClickAnalyticsService.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LukaLtaApi\Api\Click\Service;
+
+use DateTimeImmutable;
+use LukaLtaApi\Repository\ClickRepository;
+use LukaLtaApi\Value\Result\ApiResult;
+use LukaLtaApi\Value\Result\JsonResult;
+use Psr\Http\Message\ServerRequestInterface;
+
+class ClickAnalyticsService
+{
+    public function __construct(
+        private readonly ClickRepository $repository,
+    ) {
+    }
+
+    public function getClicksStats(ServerRequestInterface $request): ApiResult
+    {
+        $startDate = new DateTimeImmutable($request->getQueryParams()['startDate'] ?? 'now');
+        $endDate = new DateTimeImmutable($request->getQueryParams()['endDate'] ?? 'now');
+
+        $clicks = $this->repository->listStats($startDate, $endDate);
+
+        if (empty($clicks)) {
+            return ApiResult::from(
+                JsonResult::from('No clicks found', ['clicks' => []]),
+            );
+        }
+
+        return ApiResult::from(JsonResult::from('Clicks found', ['clicks' => $clicks]));
+    }
+
+    public function getClickSummary(): ApiResult
+    {
+        $summary = $this->repository->getSummary();
+
+        return ApiResult::from(JsonResult::from('Summary found', ['summary' => $summary->toArray()]));
+    }
+
+    public function getFilters(): ApiResult
+    {
+        $filters = $this->repository->getFilters();
+
+        return ApiResult::from(JsonResult::from('Filters found', ['filters' => $filters->toArray()]));
+    }
+}

--- a/src/Api/Click/Service/ClickService.php
+++ b/src/Api/Click/Service/ClickService.php
@@ -15,7 +15,6 @@ use LukaLtaApi\Value\Tracking\Click;
 use LukaLtaApi\Value\Tracking\ClickMetadata;
 use LukaLtaApi\Value\Tracking\Clicks;
 use LukaLtaApi\Value\Tracking\ClickTag;
-use LukaLtaApi\Value\Tracking\UserAgent;
 use Psr\Http\Message\ServerRequestInterface;
 
 class ClickService
@@ -59,22 +58,6 @@ class ClickService
         );
     }
 
-    public function getClicksStats(ServerRequestInterface $request): ApiResult
-    {
-        $startDate = new DateTimeImmutable($request->getQueryParams()['startDate'] ?? 'now');
-        $endDate = new DateTimeImmutable($request->getQueryParams()['endDate'] ?? 'now');
-
-        $clicks = $this->repository->listStats($startDate, $endDate);
-
-        if (empty($clicks)) {
-            return ApiResult::from(
-                JsonResult::from('No clicks found', ['clicks' => []]),
-            );
-        }
-
-        return ApiResult::from(JsonResult::from('Clicks found', ['clicks' => $clicks]));
-    }
-
     public function getAllClicks(ServerRequestInterface $request): ApiResult
     {
         $filter = ClickExtraFilter::parseFromQuery($request->getQueryParams());
@@ -89,19 +72,5 @@ class ClickService
         }
 
         return ApiResult::from(JsonResult::from('Clicks found', ['clicks' => $clicksData->toFrontend()]));
-    }
-
-    public function getClickSummary(): ApiResult
-    {
-        $summary = $this->repository->getSummary();
-
-        return ApiResult::from(JsonResult::from('Summary found', ['summary' => $summary->toArray()]));
-    }
-
-    public function getFilters(): ApiResult
-    {
-        $filters = $this->repository->getFilters();
-
-        return ApiResult::from(JsonResult::from('Filters found', ['filters' => $filters->toArray()]));
     }
 }


### PR DESCRIPTION
## Summary
- New `src/Api/Click/Service/ClickAnalyticsService.php` owns `getClicksStats()`, `getClickSummary()`, `getFilters()`
- `ClickService` retains `track()` and `getAllClicks()` only
- `GetClicksStatsAction`, `GetClickSummaryAction`, `GetClicksFiltersAction` now inject `ClickAnalyticsService`

## Test plan
- [ ] `php -l` on changed files: no syntax errors
- [ ] Click tracking endpoint unaffected
- [ ] Stats/summary/filter endpoints still return correct data

🤖 Generated with [Claude Code](https://claude.com/claude-code)