### PR TITLE
#111 Blog API — CRUD, Tags, Markdown, Publish Workflow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,79 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Commands
+
+```bash
+# Start dev stack (nginx, php-fpm, mysql, redis, minio, clickhouse)
+just dev
+
+# Stop dev stack
+just stop
+
+# Install PHP dependencies
+just install   # or: composer install
+
+# Lint (run inside container)
+just lint
+# Runs both phpmd and phpcs against src/
+
+# Build docker images
+just build              # development (default)
+just build production   # production
+
+# Run a single composer/PHP command inside the container
+docker compose -f docker-compose.development.yml run --rm php-fpm <cmd>
+```
+
+## Architecture
+
+**PHP 8.3 / Slim 4 API** — PSR-4 namespace `LukaLtaApi\` → `src/`.
+
+### Request Lifecycle
+
+1. `public/index.php` → `SlimFactory` bootstraps Slim with PHP-DI container
+2. `RouteMiddlewareCollector` registers all routes and middleware
+3. Routes hit `Action` classes (extend `ApiAction`) → call `Service` → call `Repository`
+4. `ApiAction::__invoke` wraps `execute()`: catches `ApiException` → typed error response, catches `Throwable` → 500
+5. Responses are built via `ApiResult::from(ResultInterface, $statusCode)->getResponse($response)`
+
+### Directory Map
+
+| Path | Purpose |
+|------|---------|
+| `src/Api/<Domain>/Action/` | One class per endpoint; extend `ApiAction` |
+| `src/Api/<Domain>/Service/` | Business logic for that domain |
+| `src/Repository/` | All DB/Redis/S3/ClickHouse access |
+| `src/Service/` | Shared services (JWT, pagination, caching, avatar, permissions) |
+| `src/Value/` | Immutable value objects; no side effects |
+| `src/Exception/` | Domain exceptions; all extend `ApiException` for typed HTTP responses |
+| `src/Slim/Middleware/` | `AuthMiddleware`, `ApiKeyPermissionMiddleware`, `CORSMiddleware` |
+| `src/App/Factory/` | DI factories for PDO, Redis, ClickHouse, MinIO, Telegram |
+| `src/Command/` | Symfony Console commands (e.g., `sessions:cleanup` runs via cron hourly) |
+| `data/mysql/` | SQL migration files — applied in filename order on container init |
+
+### Auth
+
+Two auth paths handled by `AuthMiddleware`:
+- **JWT** via `Authorization: Bearer <token>` header (issued at `POST /auth`)
+- **API key** via `X-API-Key` + `Origin` headers — permissions checked by `ApiKeyPermissionMiddleware`
+
+### Data Stores
+
+- **MySQL** — primary persistence (users, links, clicks, sessions, API keys)
+- **Redis** — session caching, link item caching (`LinkItemCachingService`)
+- **ClickHouse** — analytics/click stats (accessed via `smi2/phpclickhouse`)
+- **MinIO (S3-compatible)** — avatar uploads via `S3Repository`
+
+### WebTracking Domain
+
+`src/Api/WebTracking/` is a sub-system with its own sub-domains: `Site`, `SiteConfig`, `TrackEvent`, `TrackingUser`, `TrackingScript`, `Metric`, `Identify`. Manages web analytics separate from link click tracking.
+
+## Coding Conventions
+
+- **PSR-12** enforced by phpcs; max line length 120 (hard limit 200)
+- phpmd rules in `phpmd.xml` — run lint before pushing
+- New endpoints: create `Action` → `Service` → use existing `Repository`. Register route in `RouteMiddlewareCollector`.
+- Exceptions must extend `ApiException` to get proper HTTP status codes in responses
+- Value objects live in `src/Value/` and are constructed via named constructors (`from()`, `fromArray()`, etc.)

--- a/data/mysql/blog_post_tags.sql
+++ b/data/mysql/blog_post_tags.sql
@@ -1,0 +1,10 @@
+CREATE TABLE `blog_post_tags`
+(
+    `post_tag_id` int      NOT NULL AUTO_INCREMENT,
+    `blog_id`     char(36) NOT NULL,
+    `tag_id`      int      NOT NULL,
+    PRIMARY KEY (`post_tag_id`),
+    UNIQUE KEY `uq_blog_post_tags` (`blog_id`, `tag_id`)
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4
+  COLLATE = utf8mb4_0900_ai_ci;

--- a/data/mysql/blog_posts.sql
+++ b/data/mysql/blog_posts.sql
@@ -6,7 +6,8 @@ CREATE TABLE `blog_posts`
     `excerpt`    varchar(100) NULL,
     `content`    text         NOT NULL,
     `created_at` datetime     NOT NULL,
-    `updated_at` datetime DEFAULT NULL
+    `updated_at`   datetime    DEFAULT NULL,
+    `is_published` tinyint(1)  NOT NULL DEFAULT 0
 ) ENGINE = InnoDB
   DEFAULT CHARSET = utf8mb4
   COLLATE = utf8mb4_0900_ai_ci;

--- a/data/mysql/blog_tags.sql
+++ b/data/mysql/blog_tags.sql
@@ -1,0 +1,11 @@
+CREATE TABLE `blog_tags`
+(
+    `tag_id`     int          NOT NULL AUTO_INCREMENT,
+    `name`       varchar(50)  NOT NULL,
+    `slug`       varchar(50)  NOT NULL,
+    `created_at` datetime     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (`tag_id`),
+    UNIQUE KEY `uq_blog_tags_slug` (`slug`)
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4
+  COLLATE = utf8mb4_0900_ai_ci;

--- a/data/mysql/zz_foreign_keys.sql
+++ b/data/mysql/zz_foreign_keys.sql
@@ -6,3 +6,9 @@ ALTER TABLE `preview_access_tokens`
 
 ALTER TABLE `blog_posts`
     ADD CONSTRAINT `blog_user` FOREIGN KEY (`user_id`) REFERENCES `users` (`user_id`) ON DELETE CASCADE ON UPDATE RESTRICT;
+
+ALTER TABLE `blog_post_tags`
+    ADD CONSTRAINT `fk_bpt_blog_id` FOREIGN KEY (`blog_id`) REFERENCES `blog_posts` (`blog_id`) ON DELETE CASCADE;
+
+ALTER TABLE `blog_post_tags`
+    ADD CONSTRAINT `fk_bpt_tag_id` FOREIGN KEY (`tag_id`) REFERENCES `blog_tags` (`tag_id`) ON DELETE CASCADE;

--- a/src/Api/Blog/Action/CreateBlogAction.php
+++ b/src/Api/Blog/Action/CreateBlogAction.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LukaLtaApi\Api\Blog\Action;
+
+use LukaLtaApi\Api\ApiAction;
+use LukaLtaApi\Api\Blog\Service\BlogService;
+use LukaLtaApi\Api\RequestValidator;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+class CreateBlogAction extends ApiAction
+{
+    public function __construct(
+        private readonly RequestValidator $requestValidator,
+        private readonly BlogService      $service,
+    ) {
+    }
+
+    protected function execute(ServerRequestInterface $request, ResponseInterface $response): ResponseInterface
+    {
+        $this->requestValidator->validate($request, [
+            'title'   => ['required' => true,  'location' => 'body'],
+            'content' => ['required' => true,  'location' => 'body'],
+            'excerpt' => ['required' => false, 'location' => 'body'],
+            'tag_ids' => ['required' => false, 'location' => 'body'],
+        ]);
+
+        $userId = (int) $request->getAttribute('userId');
+
+        return $this->service->createPost($request->getParsedBody(), $userId)->getResponse($response);
+    }
+}

--- a/src/Api/Blog/Action/CreateTagAction.php
+++ b/src/Api/Blog/Action/CreateTagAction.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LukaLtaApi\Api\Blog\Action;
+
+use LukaLtaApi\Api\ApiAction;
+use LukaLtaApi\Api\Blog\Service\BlogTagService;
+use LukaLtaApi\Api\RequestValidator;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+class CreateTagAction extends ApiAction
+{
+    public function __construct(
+        private readonly RequestValidator $requestValidator,
+        private readonly BlogTagService   $service,
+    ) {
+    }
+
+    protected function execute(ServerRequestInterface $request, ResponseInterface $response): ResponseInterface
+    {
+        $this->requestValidator->validate($request, [
+            'name' => ['required' => true, 'location' => 'body'],
+        ]);
+
+        $name = $request->getParsedBody()['name'];
+
+        return $this->service->createTag($name)->getResponse($response);
+    }
+}

--- a/src/Api/Blog/Action/DeleteBlogAction.php
+++ b/src/Api/Blog/Action/DeleteBlogAction.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LukaLtaApi\Api\Blog\Action;
+
+use LukaLtaApi\Api\ApiAction;
+use LukaLtaApi\Api\Blog\Service\BlogService;
+use LukaLtaApi\Value\Blog\BlogId;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+class DeleteBlogAction extends ApiAction
+{
+    public function __construct(
+        private readonly BlogService $service,
+    ) {
+    }
+
+    protected function execute(ServerRequestInterface $request, ResponseInterface $response): ResponseInterface
+    {
+        $blogId = BlogId::fromString($request->getAttribute('blogId'));
+
+        return $this->service->deletePost($blogId)->getResponse($response);
+    }
+}

--- a/src/Api/Blog/Action/DeleteTagAction.php
+++ b/src/Api/Blog/Action/DeleteTagAction.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LukaLtaApi\Api\Blog\Action;
+
+use LukaLtaApi\Api\ApiAction;
+use LukaLtaApi\Api\Blog\Service\BlogTagService;
+use LukaLtaApi\Value\Blog\Tag\TagId;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+class DeleteTagAction extends ApiAction
+{
+    public function __construct(
+        private readonly BlogTagService $service,
+    ) {
+    }
+
+    protected function execute(ServerRequestInterface $request, ResponseInterface $response): ResponseInterface
+    {
+        $tagId = TagId::fromString($request->getAttribute('tagId'));
+
+        return $this->service->deleteTag($tagId)->getResponse($response);
+    }
+}

--- a/src/Api/Blog/Action/GetAllBlogsAction.php
+++ b/src/Api/Blog/Action/GetAllBlogsAction.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LukaLtaApi\Api\Blog\Action;
+
+use LukaLtaApi\Api\ApiAction;
+use LukaLtaApi\Api\Blog\Service\BlogService;
+use LukaLtaApi\Value\Blog\BlogFilter;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+class GetAllBlogsAction extends ApiAction
+{
+    public function __construct(
+        private readonly BlogService $service,
+    ) {
+    }
+
+    protected function execute(ServerRequestInterface $request, ResponseInterface $response): ResponseInterface
+    {
+        $filter          = BlogFilter::parseFromQuery($request->getQueryParams());
+        $authHeader      = $request->getHeaderLine('Authorization');
+        $isAuthenticated = !empty($authHeader);
+
+        return $this->service->getAllPosts($filter, $isAuthenticated)->getResponse($response);
+    }
+}

--- a/src/Api/Blog/Action/GetBlogAction.php
+++ b/src/Api/Blog/Action/GetBlogAction.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LukaLtaApi\Api\Blog\Action;
+
+use LukaLtaApi\Api\ApiAction;
+use LukaLtaApi\Api\Blog\Service\BlogService;
+use LukaLtaApi\Value\Blog\BlogId;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+class GetBlogAction extends ApiAction
+{
+    public function __construct(
+        private readonly BlogService $service,
+    ) {
+    }
+
+    protected function execute(ServerRequestInterface $request, ResponseInterface $response): ResponseInterface
+    {
+        $blogId          = BlogId::fromString($request->getAttribute('blogId'));
+        $authHeader      = $request->getHeaderLine('Authorization');
+        $isAuthenticated = !empty($authHeader);
+
+        return $this->service->getPost($blogId, $isAuthenticated)->getResponse($response);
+    }
+}

--- a/src/Api/Blog/Action/GetTagsAction.php
+++ b/src/Api/Blog/Action/GetTagsAction.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LukaLtaApi\Api\Blog\Action;
+
+use LukaLtaApi\Api\ApiAction;
+use LukaLtaApi\Api\Blog\Service\BlogTagService;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+class GetTagsAction extends ApiAction
+{
+    public function __construct(
+        private readonly BlogTagService $service,
+    ) {
+    }
+
+    /** @SuppressWarnings(PHPMD.UnusedFormalParameter) */
+    protected function execute(ServerRequestInterface $request, ResponseInterface $response): ResponseInterface
+    {
+        return $this->service->getTags()->getResponse($response);
+    }
+}

--- a/src/Api/Blog/Action/PublishBlogAction.php
+++ b/src/Api/Blog/Action/PublishBlogAction.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LukaLtaApi\Api\Blog\Action;
+
+use LukaLtaApi\Api\ApiAction;
+use LukaLtaApi\Api\Blog\Service\BlogService;
+use LukaLtaApi\Api\RequestValidator;
+use LukaLtaApi\Value\Blog\BlogId;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+class PublishBlogAction extends ApiAction
+{
+    public function __construct(
+        private readonly RequestValidator $requestValidator,
+        private readonly BlogService      $service,
+    ) {
+    }
+
+    protected function execute(ServerRequestInterface $request, ResponseInterface $response): ResponseInterface
+    {
+        $this->requestValidator->validate($request, [
+            'published' => ['required' => true, 'location' => 'body'],
+        ]);
+
+        $blogId  = BlogId::fromString($request->getAttribute('blogId'));
+        $publish = filter_var(
+            $request->getParsedBody()['published'],
+            FILTER_VALIDATE_BOOL,
+            FILTER_NULL_ON_FAILURE
+        ) ?? false;
+
+        return $this->service->togglePublish($blogId, $publish)->getResponse($response);
+    }
+}

--- a/src/Api/Blog/Action/UpdateBlogAction.php
+++ b/src/Api/Blog/Action/UpdateBlogAction.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LukaLtaApi\Api\Blog\Action;
+
+use LukaLtaApi\Api\ApiAction;
+use LukaLtaApi\Api\Blog\Service\BlogService;
+use LukaLtaApi\Value\Blog\BlogId;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+class UpdateBlogAction extends ApiAction
+{
+    public function __construct(
+        private readonly BlogService $service,
+    ) {
+    }
+
+    protected function execute(ServerRequestInterface $request, ResponseInterface $response): ResponseInterface
+    {
+        $blogId = BlogId::fromString($request->getAttribute('blogId'));
+
+        return $this->service->updatePost($blogId, $request->getParsedBody())->getResponse($response);
+    }
+}

--- a/src/Api/Blog/Service/BlogService.php
+++ b/src/Api/Blog/Service/BlogService.php
@@ -1,0 +1,158 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LukaLtaApi\Api\Blog\Service;
+
+use DateTimeImmutable;
+use Fig\Http\Message\StatusCodeInterface;
+use LukaLtaApi\Exception\ApiUserNotExistsException;
+use LukaLtaApi\Exception\BlogNotFoundException;
+use LukaLtaApi\Repository\BlogRepository;
+use LukaLtaApi\Repository\UserRepository;
+use LukaLtaApi\Value\Blog\BlogContent;
+use LukaLtaApi\Value\Blog\BlogFilter;
+use LukaLtaApi\Value\Blog\BlogId;
+use LukaLtaApi\Value\Blog\BlogPost;
+use LukaLtaApi\Value\Result\ApiResult;
+use LukaLtaApi\Value\Result\JsonResult;
+use LukaLtaApi\Value\User\UserId;
+
+class BlogService
+{
+    public function __construct(
+        private readonly BlogRepository $repository,
+        private readonly UserRepository $userRepository,
+    ) {
+    }
+
+    public function getAllPosts(BlogFilter $filter, bool $isAuthenticated): ApiResult
+    {
+        $posts = $this->repository->getAll($filter, $isAuthenticated);
+
+        foreach ($posts as $post) {
+            $tags = $this->repository->getTagsForPost(BlogId::fromString($post->getBlogId()));
+            $post->setTags($tags);
+        }
+
+        return ApiResult::from(
+            JsonResult::from('Blog posts fetched.', ['posts' => $posts->toArray()])
+        );
+    }
+
+    public function getPost(BlogId $blogId, bool $isAuthenticated): ApiResult
+    {
+        $post = $this->repository->getById($blogId, $isAuthenticated);
+
+        if ($post === null) {
+            throw new BlogNotFoundException();
+        }
+
+        $tags = $this->repository->getTagsForPost($blogId);
+        $post->setTags($tags);
+
+        return ApiResult::from(
+            JsonResult::from('Blog post fetched.', ['post' => $post->toArray()])
+        );
+    }
+
+    public function createPost(array $data, int $userId): ApiResult
+    {
+        $user = $this->userRepository->findById(UserId::fromInt($userId));
+
+        if ($user === null) {
+            throw new ApiUserNotExistsException('Authenticated user not found.', 401);
+        }
+
+        $post = BlogPost::create(
+            $user,
+            $data['title'],
+            $data['excerpt'] ?? null,
+            $data['content'],
+            false,
+            new DateTimeImmutable(),
+        );
+
+        $created = $this->repository->create($post);
+
+        $tagIds = $data['tag_ids'] ?? [];
+        if (!empty($tagIds)) {
+            $this->repository->attachTags(BlogId::fromString($created->getBlogId()), $tagIds);
+        }
+
+        $tags = $this->repository->getTagsForPost(BlogId::fromString($created->getBlogId()));
+        $created->setTags($tags);
+
+        return ApiResult::from(
+            JsonResult::from('Blog post created.', ['post' => $created->toArray()]),
+            StatusCodeInterface::STATUS_CREATED
+        );
+    }
+
+    public function updatePost(BlogId $blogId, array $data): ApiResult
+    {
+        $post = $this->repository->getById($blogId, true);
+
+        if ($post === null) {
+            throw new BlogNotFoundException();
+        }
+
+        if (isset($data['title'])) {
+            $post->setTitle($data['title']);
+        }
+
+        if (array_key_exists('excerpt', $data)) {
+            $post->setExcerpt($data['excerpt']);
+        }
+
+        if (isset($data['content'])) {
+            $post->setContent(BlogContent::fromRaw($data['content']));
+        }
+
+        $post->setUpdatedAt(new DateTimeImmutable());
+        $this->repository->update($post);
+
+        if (isset($data['tag_ids'])) {
+            $this->repository->detachTags($blogId);
+            $this->repository->attachTags($blogId, $data['tag_ids']);
+        }
+
+        $tags = $this->repository->getTagsForPost($blogId);
+        $post->setTags($tags);
+
+        return ApiResult::from(
+            JsonResult::from('Blog post updated.', ['post' => $post->toArray()])
+        );
+    }
+
+    public function deletePost(BlogId $blogId): ApiResult
+    {
+        $post = $this->repository->getById($blogId, true);
+
+        if ($post === null) {
+            throw new BlogNotFoundException();
+        }
+
+        $this->repository->delete($blogId);
+
+        return ApiResult::from(
+            JsonResult::from('Blog post deleted.'),
+            StatusCodeInterface::STATUS_NO_CONTENT
+        );
+    }
+
+    public function togglePublish(BlogId $blogId, bool $publish): ApiResult
+    {
+        $post = $this->repository->getById($blogId, true);
+
+        if ($post === null) {
+            throw new BlogNotFoundException();
+        }
+
+        $this->repository->publish($blogId, $publish);
+
+        $message = $publish ? 'Blog post published.' : 'Blog post unpublished.';
+
+        return ApiResult::from(JsonResult::from($message));
+    }
+}

--- a/src/Api/Blog/Service/BlogTagService.php
+++ b/src/Api/Blog/Service/BlogTagService.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LukaLtaApi\Api\Blog\Service;
+
+use Fig\Http\Message\StatusCodeInterface;
+use LukaLtaApi\Exception\TagNotFoundException;
+use LukaLtaApi\Repository\BlogTagRepository;
+use LukaLtaApi\Value\Blog\Tag\Tag;
+use LukaLtaApi\Value\Blog\Tag\TagId;
+use LukaLtaApi\Value\Result\ApiResult;
+use LukaLtaApi\Value\Result\JsonResult;
+
+class BlogTagService
+{
+    public function __construct(
+        private readonly BlogTagRepository $repository,
+    ) {
+    }
+
+    public function getTags(): ApiResult
+    {
+        $tags = $this->repository->getAll();
+
+        return ApiResult::from(
+            JsonResult::from('Tags fetched.', ['tags' => $tags->toArray()])
+        );
+    }
+
+    public function createTag(string $name): ApiResult
+    {
+        $tag     = Tag::create($name);
+        $created = $this->repository->create($tag);
+
+        return ApiResult::from(
+            JsonResult::from('Tag created.', ['tag' => $created->toArray()]),
+            StatusCodeInterface::STATUS_CREATED
+        );
+    }
+
+    public function deleteTag(TagId $tagId): ApiResult
+    {
+        $tag = $this->repository->getById($tagId);
+
+        if ($tag === null) {
+            throw new TagNotFoundException();
+        }
+
+        $this->repository->delete($tagId);
+
+        return ApiResult::from(
+            JsonResult::from('Tag deleted.'),
+            StatusCodeInterface::STATUS_NO_CONTENT
+        );
+    }
+}

--- a/src/Exception/BlogNotFoundException.php
+++ b/src/Exception/BlogNotFoundException.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace LukaLtaApi\Exception;
+
+class BlogNotFoundException extends ApiException
+{
+    public function __construct(string $message = 'Blog post not found.', \Throwable $previous = null)
+    {
+        parent::__construct($message, 404, $previous);
+    }
+}

--- a/src/Exception/TagNotFoundException.php
+++ b/src/Exception/TagNotFoundException.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace LukaLtaApi\Exception;
+
+class TagNotFoundException extends ApiException
+{
+    public function __construct(string $message = 'Tag not found.', \Throwable $previous = null)
+    {
+        parent::__construct($message, 404, $previous);
+    }
+}

--- a/src/Repository/BlogRepository.php
+++ b/src/Repository/BlogRepository.php
@@ -1,0 +1,277 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LukaLtaApi\Repository;
+
+use LukaLtaApi\Exception\ApiDatabaseException;
+use LukaLtaApi\Value\Blog\BlogFilter;
+use LukaLtaApi\Value\Blog\BlogId;
+use LukaLtaApi\Value\Blog\BlogPost;
+use LukaLtaApi\Value\Blog\BlogPosts;
+use LukaLtaApi\Value\Blog\Tag\Tags;
+use PDO;
+use PDOException;
+
+class BlogRepository
+{
+    private const BLOG_SELECT = <<<SQL
+        SELECT
+            bp.blog_id,
+            bp.title,
+            bp.excerpt,
+            bp.content,
+            bp.is_published,
+            bp.created_at  AS blog_created_at,
+            bp.updated_at  AS blog_updated_at,
+            u.user_id,
+            u.username,
+            u.email,
+            u.password,
+            u.avatar_url,
+            u.is_active,
+            u.last_active,
+            u.created_at,
+            u.updated_at
+        FROM blog_posts bp
+        INNER JOIN users u ON bp.user_id = u.user_id
+    SQL;
+
+    public function __construct(
+        private readonly PDO $pdo,
+    ) {
+    }
+
+    public function create(BlogPost $post): BlogPost
+    {
+        $sql = <<<SQL
+            INSERT INTO blog_posts (blog_id, user_id, title, excerpt, content, is_published, created_at)
+            VALUES (:blog_id, :user_id, :title, :excerpt, :content, :is_published, NOW())
+        SQL;
+
+        try {
+            $this->pdo->beginTransaction();
+            $stmt = $this->pdo->prepare($sql);
+            $stmt->execute([
+                'blog_id'      => $post->getBlogId(),
+                'user_id'      => $post->getUser()->getUserId()?->asInt(),
+                'title'        => $post->getTitle(),
+                'excerpt'      => $post->getExcerpt(),
+                'content'      => $post->getContent()->getContent(),
+                'is_published' => $post->isPublished() ? 1 : 0,
+            ]);
+            $this->pdo->commit();
+        } catch (PDOException $exception) {
+            $this->pdo->rollBack();
+            throw new ApiDatabaseException('Failed to create blog post.', previous: $exception);
+        }
+
+        return $post;
+    }
+
+    public function getById(BlogId $blogId, bool $includeUnpublished = false): ?BlogPost
+    {
+        $sql = self::BLOG_SELECT . ' WHERE bp.blog_id = :blog_id';
+
+        if (!$includeUnpublished) {
+            $sql .= ' AND bp.is_published = 1';
+        }
+
+        try {
+            $stmt = $this->pdo->prepare($sql);
+            $stmt->execute(['blog_id' => $blogId->asString()]);
+            $row = $stmt->fetch();
+        } catch (PDOException $exception) {
+            throw new ApiDatabaseException('Failed to fetch blog post.', previous: $exception);
+        }
+
+        if ($row === false) {
+            return null;
+        }
+
+        return BlogPost::fromDatabase($row);
+    }
+
+    public function getAll(BlogFilter $filter, bool $includeUnpublished = false): BlogPosts
+    {
+        [$conditions, $params] = $this->buildWhereConditions($filter, $includeUnpublished);
+
+        $sql  = self::BLOG_SELECT;
+        $sql .= empty($conditions) ? '' : ' WHERE ' . implode(' AND ', $conditions);
+        $sql .= $this->buildOrderBy($filter);
+        $sql .= ' LIMIT :pageSize OFFSET :offset';
+
+        $params['pageSize'] = $filter->getPageSize();
+        $params['offset']   = $filter->getOffset();
+
+        try {
+            $stmt = $this->pdo->prepare($sql);
+            foreach ($params as $key => $value) {
+                $type = is_int($value) ? PDO::PARAM_INT : PDO::PARAM_STR;
+                $stmt->bindValue($key, $value, $type);
+            }
+            $stmt->execute();
+
+            $posts = [];
+            foreach ($stmt as $row) {
+                $posts[] = BlogPost::fromDatabase($row);
+            }
+        } catch (PDOException $exception) {
+            throw new ApiDatabaseException('Failed to fetch blog posts.', previous: $exception);
+        }
+
+        return BlogPosts::from(...$posts);
+    }
+
+    private function buildWhereConditions(BlogFilter $filter, bool $includeUnpublished): array
+    {
+        $conditions = [];
+        $params     = [];
+
+        if (!$includeUnpublished) {
+            $conditions[] = 'bp.is_published = 1';
+        }
+
+        $queryParams = $filter->getQueryParameter();
+        if (!empty($queryParams['title'])) {
+            $conditions[]    = 'bp.title LIKE :title';
+            $params['title'] = '%' . $queryParams['title'] . '%';
+        }
+
+        $tagId = $filter->getTagId();
+        if ($tagId !== null) {
+            $conditions[]      = 'bp.blog_id IN (SELECT blog_id FROM blog_post_tags WHERE tag_id = :tag_id)';
+            $params['tag_id']  = $tagId;
+        }
+
+        return [$conditions, $params];
+    }
+
+    private function buildOrderBy(BlogFilter $filter): string
+    {
+        $sortColumn    = $filter->getSortColumn();
+        $sortDirection = $filter->getSortDirection();
+        $allowedColumns = ['bp.created_at', 'bp.title', 'bp.updated_at'];
+
+        if ($sortColumn !== null && $sortDirection !== null && in_array($sortColumn, $allowedColumns, true)) {
+            return " ORDER BY {$sortColumn} {$sortDirection}";
+        }
+
+        return ' ORDER BY bp.created_at DESC';
+    }
+
+    public function update(BlogPost $post): BlogPost
+    {
+        $sql = <<<SQL
+            UPDATE blog_posts
+            SET title        = :title,
+                excerpt      = :excerpt,
+                content      = :content,
+                is_published = :is_published,
+                updated_at   = NOW()
+            WHERE blog_id = :blog_id
+        SQL;
+
+        try {
+            $this->pdo->beginTransaction();
+            $stmt = $this->pdo->prepare($sql);
+            $stmt->execute([
+                'title'        => $post->getTitle(),
+                'excerpt'      => $post->getExcerpt(),
+                'content'      => $post->getContent()->getContent(),
+                'is_published' => $post->isPublished() ? 1 : 0,
+                'blog_id'      => $post->getBlogId(),
+            ]);
+            $this->pdo->commit();
+        } catch (PDOException $exception) {
+            $this->pdo->rollBack();
+            throw new ApiDatabaseException('Failed to update blog post.', previous: $exception);
+        }
+
+        return $post;
+    }
+
+    public function delete(BlogId $blogId): void
+    {
+        $sql = 'DELETE FROM blog_posts WHERE blog_id = :blog_id';
+
+        try {
+            $this->pdo->beginTransaction();
+            $stmt = $this->pdo->prepare($sql);
+            $stmt->execute(['blog_id' => $blogId->asString()]);
+            $this->pdo->commit();
+        } catch (PDOException $exception) {
+            $this->pdo->rollBack();
+            throw new ApiDatabaseException('Failed to delete blog post.', previous: $exception);
+        }
+    }
+
+    public function publish(BlogId $blogId, bool $published): void
+    {
+        $sql = 'UPDATE blog_posts SET is_published = :is_published, updated_at = NOW() WHERE blog_id = :blog_id';
+
+        try {
+            $stmt = $this->pdo->prepare($sql);
+            $stmt->execute([
+                'is_published' => $published ? 1 : 0,
+                'blog_id'      => $blogId->asString(),
+            ]);
+        } catch (PDOException $exception) {
+            throw new ApiDatabaseException('Failed to update publish status.', previous: $exception);
+        }
+    }
+
+    public function attachTags(BlogId $blogId, array $tagIds): void
+    {
+        if (empty($tagIds)) {
+            return;
+        }
+
+        $sql = 'INSERT IGNORE INTO blog_post_tags (blog_id, tag_id) VALUES (:blog_id, :tag_id)';
+
+        try {
+            $stmt = $this->pdo->prepare($sql);
+            foreach ($tagIds as $tagId) {
+                $stmt->execute(['blog_id' => $blogId->asString(), 'tag_id' => (int) $tagId]);
+            }
+        } catch (PDOException $exception) {
+            throw new ApiDatabaseException('Failed to attach tags.', previous: $exception);
+        }
+    }
+
+    public function detachTags(BlogId $blogId): void
+    {
+        $sql = 'DELETE FROM blog_post_tags WHERE blog_id = :blog_id';
+
+        try {
+            $stmt = $this->pdo->prepare($sql);
+            $stmt->execute(['blog_id' => $blogId->asString()]);
+        } catch (PDOException $exception) {
+            throw new ApiDatabaseException('Failed to detach tags.', previous: $exception);
+        }
+    }
+
+    public function getTagsForPost(BlogId $blogId): Tags
+    {
+        $sql = <<<SQL
+            SELECT t.tag_id, t.name, t.slug, t.created_at
+            FROM blog_tags t
+            INNER JOIN blog_post_tags bpt ON t.tag_id = bpt.tag_id
+            WHERE bpt.blog_id = :blog_id
+        SQL;
+
+        try {
+            $stmt = $this->pdo->prepare($sql);
+            $stmt->execute(['blog_id' => $blogId->asString()]);
+
+            $tags = [];
+            foreach ($stmt as $row) {
+                $tags[] = \LukaLtaApi\Value\Blog\Tag\Tag::fromDatabase($row);
+            }
+        } catch (PDOException $exception) {
+            throw new ApiDatabaseException('Failed to fetch tags for post.', previous: $exception);
+        }
+
+        return Tags::from(...$tags);
+    }
+}

--- a/src/Repository/BlogTagRepository.php
+++ b/src/Repository/BlogTagRepository.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LukaLtaApi\Repository;
+
+use LukaLtaApi\Exception\ApiDatabaseException;
+use LukaLtaApi\Value\Blog\Tag\Tag;
+use LukaLtaApi\Value\Blog\Tag\TagId;
+use LukaLtaApi\Value\Blog\Tag\TagSlug;
+use LukaLtaApi\Value\Blog\Tag\Tags;
+use PDO;
+use PDOException;
+
+class BlogTagRepository
+{
+    public function __construct(
+        private readonly PDO $pdo,
+    ) {
+    }
+
+    public function create(Tag $tag): Tag
+    {
+        $sql = <<<SQL
+            INSERT INTO blog_tags (name, slug)
+            VALUES (:name, :slug)
+        SQL;
+
+        try {
+            $this->pdo->beginTransaction();
+            $stmt = $this->pdo->prepare($sql);
+            $stmt->execute([
+                'name' => (string) $tag->getName(),
+                'slug' => (string) $tag->getSlug(),
+            ]);
+            $id = (int) $this->pdo->lastInsertId();
+            $this->pdo->commit();
+        } catch (PDOException $exception) {
+            $this->pdo->rollBack();
+            throw new ApiDatabaseException('Failed to create tag.', previous: $exception);
+        }
+
+        return Tag::fromDatabase([
+            'tag_id'     => $id,
+            'name'       => (string) $tag->getName(),
+            'slug'       => (string) $tag->getSlug(),
+            'created_at' => $tag->getCreatedAt()->format('Y-m-d H:i:s'),
+        ]);
+    }
+
+    public function getById(TagId $tagId): ?Tag
+    {
+        $sql = 'SELECT * FROM blog_tags WHERE tag_id = :tag_id';
+
+        try {
+            $stmt = $this->pdo->prepare($sql);
+            $stmt->execute(['tag_id' => $tagId->asInt()]);
+            $row = $stmt->fetch();
+        } catch (PDOException $exception) {
+            throw new ApiDatabaseException('Failed to fetch tag.', previous: $exception);
+        }
+
+        return $row !== false ? Tag::fromDatabase($row) : null;
+    }
+
+    public function getBySlug(TagSlug $slug): ?Tag
+    {
+        $sql = 'SELECT * FROM blog_tags WHERE slug = :slug';
+
+        try {
+            $stmt = $this->pdo->prepare($sql);
+            $stmt->execute(['slug' => (string) $slug]);
+            $row = $stmt->fetch();
+        } catch (PDOException $exception) {
+            throw new ApiDatabaseException('Failed to fetch tag by slug.', previous: $exception);
+        }
+
+        return $row !== false ? Tag::fromDatabase($row) : null;
+    }
+
+    public function getAll(): Tags
+    {
+        $sql = 'SELECT * FROM blog_tags ORDER BY name ASC';
+
+        try {
+            $stmt = $this->pdo->prepare($sql);
+            $stmt->execute();
+
+            $tags = [];
+            foreach ($stmt as $row) {
+                $tags[] = Tag::fromDatabase($row);
+            }
+        } catch (PDOException $exception) {
+            throw new ApiDatabaseException('Failed to fetch tags.', previous: $exception);
+        }
+
+        return Tags::from(...$tags);
+    }
+
+    public function delete(TagId $tagId): void
+    {
+        $sql = 'DELETE FROM blog_tags WHERE tag_id = :tag_id';
+
+        try {
+            $this->pdo->beginTransaction();
+            $stmt = $this->pdo->prepare($sql);
+            $stmt->execute(['tag_id' => $tagId->asInt()]);
+            $this->pdo->commit();
+        } catch (PDOException $exception) {
+            $this->pdo->rollBack();
+            throw new ApiDatabaseException('Failed to delete tag.', previous: $exception);
+        }
+    }
+}

--- a/src/Slim/RouteMiddlewareCollector.php
+++ b/src/Slim/RouteMiddlewareCollector.php
@@ -2,6 +2,15 @@
 
 namespace LukaLtaApi\Slim;
 
+use LukaLtaApi\Api\Blog\Action\CreateBlogAction;
+use LukaLtaApi\Api\Blog\Action\CreateTagAction;
+use LukaLtaApi\Api\Blog\Action\DeleteBlogAction;
+use LukaLtaApi\Api\Blog\Action\DeleteTagAction;
+use LukaLtaApi\Api\Blog\Action\GetAllBlogsAction;
+use LukaLtaApi\Api\Blog\Action\GetBlogAction;
+use LukaLtaApi\Api\Blog\Action\GetTagsAction;
+use LukaLtaApi\Api\Blog\Action\PublishBlogAction;
+use LukaLtaApi\Api\Blog\Action\UpdateBlogAction;
 use LukaLtaApi\Api\ApiKey\Action\CreateApiKeyAction;
 use LukaLtaApi\Api\ApiKey\Action\GetAllApiKeysAction;
 use LukaLtaApi\Api\Auth\Action\AuthAction;
@@ -251,6 +260,21 @@ class RouteMiddlewareCollector
 
             $app->group('/statistics', function (RouteCollectorProxy $statistics) use ($app) {
                 $statistics->get('/', GetStatisticsAction::class);
+            })->add(AuthMiddleware::class);
+
+            // Blog — public read routes
+            $app->get('/blog', GetAllBlogsAction::class);
+            $app->get('/blog/tags', GetTagsAction::class);
+            $app->get('/blog/{blogId}', GetBlogAction::class);
+
+            // Blog — protected write routes
+            $app->group('/blog', function (RouteCollectorProxy $blog) {
+                $blog->post('', CreateBlogAction::class);
+                $blog->put('/{blogId}', UpdateBlogAction::class);
+                $blog->delete('/{blogId}', DeleteBlogAction::class);
+                $blog->patch('/{blogId}/publish', PublishBlogAction::class);
+                $blog->post('/tags', CreateTagAction::class);
+                $blog->delete('/tags/{tagId:[0-9]+}', DeleteTagAction::class);
             })->add(AuthMiddleware::class);
 
             $app->group('/site', function (RouteCollectorProxy $site) use ($app) {

--- a/src/Value/AbstractDataTableFilterParameter.php
+++ b/src/Value/AbstractDataTableFilterParameter.php
@@ -69,6 +69,11 @@ abstract class AbstractDataTableFilterParameter
         return $query;
     }
 
+    public function getPage(): int
+    {
+        return $this->page;
+    }
+
     public function getPageSize(): int
     {
         return $this->pageSize;

--- a/src/Value/Blog/BlogFilter.php
+++ b/src/Value/Blog/BlogFilter.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LukaLtaApi\Value\Blog;
+
+use LukaLtaApi\Value\AbstractDataTableFilterParameter;
+
+class BlogFilter extends AbstractDataTableFilterParameter
+{
+    protected function getExtraFilterName(): array
+    {
+        return ['title'];
+    }
+
+    public function getTagId(): ?int
+    {
+        $params = $this->getQueryParameter();
+
+        return isset($params['tag_id']) ? (int) $params['tag_id'] : null;
+    }
+
+    public function getSortColumn(): ?string
+    {
+        $params = $this->getQueryParameter();
+
+        return $params['sortColumn'] ?? null;
+    }
+
+    public function getSortDirection(): ?string
+    {
+        $params = $this->getQueryParameter();
+        $dir = strtoupper($params['sortDirection'] ?? '');
+
+        return in_array($dir, ['ASC', 'DESC'], true) ? $dir : null;
+    }
+
+    public function getOffset(): int
+    {
+        return ($this->getPage() - 1) * $this->getPageSize();
+    }
+}

--- a/src/Value/Blog/BlogId.php
+++ b/src/Value/Blog/BlogId.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LukaLtaApi\Value\Blog;
+
+use LukaLtaApi\Exception\ApiValidationException;
+use LukaLtaApi\Value\IdentifierInterface;
+use Ramsey\Uuid\Uuid;
+
+class BlogId implements IdentifierInterface
+{
+    private function __construct(
+        private readonly string $value,
+    ) {
+    }
+
+    public static function generate(): self
+    {
+        return new self(Uuid::uuid4()->toString());
+    }
+
+    public static function fromString(string $value): self
+    {
+        if (empty($value)) {
+            throw new ApiValidationException('Blog ID cannot be empty.', 400);
+        }
+
+        return new self($value);
+    }
+
+    public function asString(): string
+    {
+        return $this->value;
+    }
+
+    public function asInt(): int
+    {
+        throw new \RuntimeException('BlogId is UUID-based and cannot be cast to int.');
+    }
+}

--- a/src/Value/Blog/BlogPost.php
+++ b/src/Value/Blog/BlogPost.php
@@ -3,11 +3,14 @@
 namespace LukaLtaApi\Value\Blog;
 
 use DateTimeImmutable;
+use LukaLtaApi\Value\Blog\Tag\Tags;
 use LukaLtaApi\Value\User\User;
 use Ramsey\Uuid\Uuid;
 
 class BlogPost
 {
+    private Tags $tags;
+
     private function __construct(
         private readonly string            $blogId,
         private readonly User              $user,
@@ -18,6 +21,7 @@ class BlogPost
         private readonly DateTimeImmutable $createdAt,
         private ?DateTimeImmutable         $updatedAt,
     ) {
+        $this->tags = Tags::empty();
     }
 
     public static function create(
@@ -71,24 +75,36 @@ class BlogPost
             $row['title'],
             $row['excerpt'],
             BlogContent::fromRaw($row['content']),
-            $row['is_published'],
-            new DateTimeImmutable($row['created_at']),
-            isset($row['updated_at']) ? new DateTimeImmutable($row['updated_at']) : null
+            (bool) $row['is_published'],
+            new DateTimeImmutable($row['blog_created_at']),
+            isset($row['blog_updated_at']) ? new DateTimeImmutable($row['blog_updated_at']) : null
         );
     }
 
     public function toArray(): array
     {
         return [
-            'blogId' => $this->getBlogId(),
-            'user' => $this->getUser()->toArray(),
-            'title' => $this->getTitle(),
-            'excerpt' => $this->getExcerpt(),
-            'content' => $this->content->getContent(),
+            'blogId'      => $this->getBlogId(),
+            'user'        => $this->getUser()->toArray(),
+            'title'       => $this->getTitle(),
+            'excerpt'     => $this->getExcerpt(),
+            'content'     => $this->content->getContent(),
+            'contentHtml' => $this->content->toHtml(),
             'isPublished' => $this->isPublished,
-            'createdAt' => $this->createdAt->format('Y-m-d H:i:s'),
-            'updatedAt' => $this->updatedAt?->format('Y-m-d H:i:s'),
+            'tags'        => $this->tags->toArray(),
+            'createdAt'   => $this->createdAt->format('Y-m-d H:i:s'),
+            'updatedAt'   => $this->updatedAt?->format('Y-m-d H:i:s'),
         ];
+    }
+
+    public function getTags(): Tags
+    {
+        return $this->tags;
+    }
+
+    public function setTags(Tags $tags): void
+    {
+        $this->tags = $tags;
     }
 
     public function getBlogId(): string

--- a/src/Value/Blog/BlogPosts.php
+++ b/src/Value/Blog/BlogPosts.php
@@ -26,16 +26,7 @@ class BlogPosts implements IteratorAggregate, JsonSerializable, Countable
         $blogPosts = [];
 
         foreach ($this->blogPosts as $blogPost) {
-            $blogPosts[] = [
-                'blogId' => $blogPost->getBlogId(),
-                'title' => $blogPost->getTitle(),
-                'excerpt' => $blogPost->getExcerpt(),
-                'content' => $blogPost->getContent()->toHtml(),
-                'createdAt' => $blogPost->getCreatedAt()->format('Y-m-d H:i:s'),
-                'updatedAt' => $blogPost->getUpdatedAt()?->format('Y-m-d H:i:s'),
-                'isPublished' => $blogPost->isPublished(),
-                'user' => $blogPost->getUser()->toArray(),
-            ];
+            $blogPosts[] = $blogPost->toArray();
         }
 
         return $blogPosts;

--- a/src/Value/Blog/Tag/Tag.php
+++ b/src/Value/Blog/Tag/Tag.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LukaLtaApi\Value\Blog\Tag;
+
+use DateTimeImmutable;
+
+class Tag
+{
+    private function __construct(
+        private readonly ?TagId           $tagId,
+        private readonly TagName          $name,
+        private readonly TagSlug          $slug,
+        private readonly DateTimeImmutable $createdAt,
+    ) {
+    }
+
+    public static function create(string $name): self
+    {
+        return new self(
+            null,
+            TagName::fromString($name),
+            TagSlug::fromName($name),
+            new DateTimeImmutable(),
+        );
+    }
+
+    public static function fromDatabase(array $row): self
+    {
+        return new self(
+            TagId::fromInt((int) $row['tag_id']),
+            TagName::fromString($row['name']),
+            TagSlug::fromString($row['slug']),
+            new DateTimeImmutable($row['created_at']),
+        );
+    }
+
+    public function getTagId(): ?TagId
+    {
+        return $this->tagId;
+    }
+
+    public function getName(): TagName
+    {
+        return $this->name;
+    }
+
+    public function getSlug(): TagSlug
+    {
+        return $this->slug;
+    }
+
+    public function getCreatedAt(): DateTimeImmutable
+    {
+        return $this->createdAt;
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'tagId'     => $this->tagId?->asInt(),
+            'name'      => (string) $this->name,
+            'slug'      => (string) $this->slug,
+            'createdAt' => $this->createdAt->format('Y-m-d H:i:s'),
+        ];
+    }
+}

--- a/src/Value/Blog/Tag/TagId.php
+++ b/src/Value/Blog/Tag/TagId.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LukaLtaApi\Value\Blog\Tag;
+
+use LukaLtaApi\Exception\ApiValidationException;
+use LukaLtaApi\Value\IdentifierInterface;
+
+class TagId implements IdentifierInterface
+{
+    private function __construct(
+        private readonly int $value,
+    ) {
+        if ($value <= 0) {
+            throw new ApiValidationException('Tag ID must be greater than zero.', 400);
+        }
+    }
+
+    public static function fromInt(int $value): self
+    {
+        return new self($value);
+    }
+
+    public static function fromString(string $value): self
+    {
+        return new self((int) $value);
+    }
+
+    public function asInt(): int
+    {
+        return $this->value;
+    }
+
+    public function asString(): string
+    {
+        return (string) $this->value;
+    }
+}

--- a/src/Value/Blog/Tag/TagName.php
+++ b/src/Value/Blog/Tag/TagName.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LukaLtaApi\Value\Blog\Tag;
+
+use LukaLtaApi\Exception\ApiInvalidArgumentException;
+
+class TagName
+{
+    private function __construct(
+        private readonly string $value,
+    ) {
+        if (empty(trim($value))) {
+            throw new ApiInvalidArgumentException('Tag name cannot be empty.', 400);
+        }
+
+        if (mb_strlen($value) > 50) {
+            throw new ApiInvalidArgumentException('Tag name must not exceed 50 characters.', 400);
+        }
+    }
+
+    public static function fromString(string $value): self
+    {
+        return new self($value);
+    }
+
+    public function __toString(): string
+    {
+        return $this->value;
+    }
+}

--- a/src/Value/Blog/Tag/TagSlug.php
+++ b/src/Value/Blog/Tag/TagSlug.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LukaLtaApi\Value\Blog\Tag;
+
+class TagSlug
+{
+    private function __construct(
+        private readonly string $value,
+    ) {
+    }
+
+    public static function fromName(string $name): self
+    {
+        $slug = strtolower(preg_replace('/[^a-zA-Z0-9]+/', '-', trim($name)));
+        $slug = trim($slug, '-');
+
+        return new self($slug);
+    }
+
+    public static function fromString(string $value): self
+    {
+        return new self($value);
+    }
+
+    public function __toString(): string
+    {
+        return $this->value;
+    }
+}

--- a/src/Value/Blog/Tag/Tags.php
+++ b/src/Value/Blog/Tag/Tags.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LukaLtaApi\Value\Blog\Tag;
+
+use Countable;
+use Generator;
+use IteratorAggregate;
+use JsonSerializable;
+
+class Tags implements IteratorAggregate, JsonSerializable, Countable
+{
+    private readonly array $tags;
+
+    private function __construct(Tag ...$tags)
+    {
+        $this->tags = $tags;
+    }
+
+    public static function from(Tag ...$tags): self
+    {
+        return new self(...$tags);
+    }
+
+    public static function empty(): self
+    {
+        return new self();
+    }
+
+    public function getIterator(): Generator
+    {
+        yield from $this->tags;
+    }
+
+    public function count(): int
+    {
+        return count($this->tags);
+    }
+
+    public function jsonSerialize(): array
+    {
+        return $this->tags;
+    }
+
+    public function toArray(): array
+    {
+        return array_map(static fn(Tag $tag) => $tag->toArray(), $this->tags);
+    }
+}


### PR DESCRIPTION
## Summary

- Blog CRUD endpoints with Markdown content support (via `league/commonmark`)
- Tag system with own table + junction table — reusable, filterable
- Draft/publish workflow: `is_published` flag, drafts hidden from public GET
- 3 public endpoints (no auth), 6 protected endpoints (JWT required)

## New Endpoints

| Method | Route | Auth |
|--------|-------|------|
| GET | `/api/v1/blog` | no (shows only published; with JWT shows all) |
| GET | `/api/v1/blog/tags` | no |
| GET | `/api/v1/blog/{blogId}` | no |
| POST | `/api/v1/blog` | JWT |
| PUT | `/api/v1/blog/{blogId}` | JWT |
| DELETE | `/api/v1/blog/{blogId}` | JWT |
| PATCH | `/api/v1/blog/{blogId}/publish` | JWT |
| POST | `/api/v1/blog/tags` | JWT |
| DELETE | `/api/v1/blog/tags/{tagId}` | JWT |

## DB Changes

- `blog_posts.sql` — added `is_published tinyint(1) NOT NULL DEFAULT 0`
- `blog_tags.sql` — new table (`tag_id`, `name`, `slug`)
- `blog_post_tags.sql` — junction table
- `zz_foreign_keys.sql` — FKs for `blog_post_tags` → `blog_posts` + `blog_tags`

## Test Plan

- [ ] Recreate MySQL volume: `docker compose down -v && just dev`
- [ ] `GET /api/v1/blog` → empty list, 200
- [ ] `POST /api/v1/blog` without JWT → 401
- [ ] `POST /api/v1/blog` with JWT → 201, post returned (is_published=false)
- [ ] `GET /api/v1/blog` → post NOT visible (unpublished)
- [ ] `PATCH /api/v1/blog/{id}/publish` body `{"published":true}` → 200
- [ ] `GET /api/v1/blog` → post now visible
- [ ] `POST /api/v1/blog/tags` body `{"name":"PHP"}` → 201
- [ ] `GET /api/v1/blog?tag_id=1` → filtered list
- [ ] `DELETE /api/v1/blog/{id}` → 204

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Blog-Verwaltung: Erstellen, Lesen, Aktualisieren und Löschen von Blog-Beiträgen.
  * Veröffentlichungs-Funktionalität für Blog-Beiträge.
  * Tag-System für Blog-Beiträge mit vollem CRUD-Support.
  * Filtering und Sortierung von Blog-Listen nach Tags.

* **Documentation**
  * Projektanleitungen und Architektur-Dokumentation hinzugefügt.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->